### PR TITLE
fix: keep validation prompt under action limits

### DIFF
--- a/src/cli/validate-prompt.ts
+++ b/src/cli/validate-prompt.ts
@@ -6,40 +6,55 @@
  * Also used by the CI pipeline to inject the prompt into the
  * Pi coding-agent action without hardcoding it in the YAML.
  *
- * Appends a git diff section (modified tracked files + untracked new files)
- * so the LLM knows exactly which files changed without having to figure it out itself.
+ * Appends the entry files that need semantic validation. Bulk metric updates are
+ * intentionally omitted so the GitHub Action input stays below process limits.
  */
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { VALIDATE_PROMPT } from "../core/validate-prompt";
 
-// Collect modified tracked files
-let diffStat = "";
-try {
-	diffStat = execSync("git diff --stat", {
-		encoding: "utf-8",
-		stdio: ["pipe", "pipe", "pipe"],
-	}).trim();
-} catch {
-	// Not in a git repo or no diff — that's fine
+function git(args: string[]): string {
+	try {
+		return execFileSync("git", args, {
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+		}).trim();
+	} catch {
+		return "";
+	}
 }
 
-// Collect new untracked files (e.g. newly discovered entries)
-let untracked = "";
-try {
-	untracked = execSync("git ls-files --others --exclude-standard", {
-		encoding: "utf-8",
-		stdio: ["pipe", "pipe", "pipe"],
-	}).trim();
-} catch {
-	// Not in a git repo — that's fine
+function entryPathsFrom(output: string): string[] {
+	if (!output) return [];
+	return output
+		.split("\n")
+		.map((path) => path.trim())
+		.filter((path) => path.startsWith("data/entries/") && path.endsWith(".json"));
 }
+
+const modifiedEntries = entryPathsFrom(
+	git([
+		"diff",
+		"--name-only",
+		"--diff-filter=AM",
+		"-G",
+		'"(name|description|url|category)"',
+		"--",
+		"data/entries",
+	]),
+);
+
+const newEntries = entryPathsFrom(
+	git(["ls-files", "--others", "--exclude-standard", "--", "data/entries"]),
+);
+
+const entriesToValidate = Array.from(new Set([...modifiedEntries, ...newEntries])).sort();
 
 let prompt = VALIDATE_PROMPT;
-if (diffStat || untracked) {
-	let section = "\n\nChanged files:";
-	if (diffStat) section += `\n\nModified:\n${diffStat}\n`;
-	if (untracked) section += `\n\nNew (untracked):\n${untracked}\n`;
-	prompt += section;
+if (entriesToValidate.length > 0) {
+	prompt += `\n\nEntry files requiring validation:\n${entriesToValidate.join("\n")}`;
+} else {
+	prompt +=
+		"\n\nNo entry files require semantic validation; only generated metadata or popularity metrics changed.";
 }
 
 process.stdout.write(prompt);


### PR DESCRIPTION
## Summary

Thanks for maintaining this curated list and the daily automation around it.

This PR is intended to fix the current `Daily Pipeline` GitHub Actions failure. The last successful scheduled run was #60 on 2026-06-04, and runs #61 through #65 failed from 2026-06-05 through 2026-06-09. As a result, the automated daily data update has not completed for the last five scheduled runs.

The failure happens before the Pi action can start:

```text
Argument list too long
```

The generated validation prompt had grown large because it appended the full `git diff --stat` output for thousands of daily metadata and popularity updates. GitHub Actions then failed while starting the Node-based action process with that oversized input.

## Changes

This changes the validation prompt generator to include only entry files that need semantic review:

- newly discovered `data/entries/*.json` files
- modified entry files only when `name`, `description`, `url`, or `category` changed
- omits bulk metadata, score, popularity, and README churn from the action input

The existing workflow and action contract stay unchanged; this only reduces the text passed through the current `prompt` input.

## Validation

Reproduced the prompt-size reduction against failed workflow artifacts:

- run #61: approximately 146 KB to 8.6 KB
- run #65: approximately 161 KB to 14.3 KB

Local checks:

- `bun run check`
- `bun test`

This should keep the validation prompt below the GitHub Actions process startup limit and allow the daily pipeline to proceed to validation, README regeneration, and PR creation again.