### PR TITLE
fix: preserve higher-priority source metadata

### DIFF
--- a/src/process/duplicate-action.test.ts
+++ b/src/process/duplicate-action.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CategorizedEntry, DiscoveryCandidate } from "../core/types.ts";
+import { Category, EntrySource } from "../core/types.ts";
+import { resolveDuplicateAction, sourcePriority } from "./duplicate-action.ts";
+
+function entryForSource(source: EntrySource): CategorizedEntry {
+	return {
+		id: "owner-pi-ext",
+		name: "owner/pi-ext",
+		url:
+			source === EntrySource.NpmSearch
+				? "https://www.npmjs.com/package/pi-ext"
+				: "https://github.com/owner/pi-ext",
+		source,
+		description: "A Pi extension",
+		metadata: {},
+		category: Category.Extension,
+	};
+}
+
+function discoveryForSource(source: EntrySource): DiscoveryCandidate {
+	return {
+		url:
+			source === EntrySource.NpmSearch
+				? "https://www.npmjs.com/package/pi-ext"
+				: "https://github.com/owner/pi-ext",
+		source,
+		metadata: {},
+	};
+}
+
+describe("resolveDuplicateAction", () => {
+	test("replaces lower-priority existing entries with higher-priority candidates", () => {
+		const discovery = discoveryForSource(EntrySource.NpmSearch);
+		const existingEntry = entryForSource(EntrySource.GitHubSearch);
+
+		expect(sourcePriority(discovery.source)).toBeLessThan(sourcePriority(existingEntry.source));
+		expect(resolveDuplicateAction(discovery, { existingEntry })).toBe("replace");
+	});
+
+	test("refreshes duplicates from the same source", () => {
+		const discovery = discoveryForSource(EntrySource.NpmSearch);
+		const existingEntry = entryForSource(EntrySource.NpmSearch);
+
+		expect(sourcePriority(discovery.source)).toBe(sourcePriority(existingEntry.source));
+		expect(resolveDuplicateAction(discovery, { existingEntry })).toBe("refresh");
+	});
+
+	test("skips lower-priority candidates instead of refreshing higher-priority entries", () => {
+		const discovery = discoveryForSource(EntrySource.GitHubSearch);
+		const existingEntry = entryForSource(EntrySource.NpmSearch);
+
+		expect(sourcePriority(discovery.source)).toBeGreaterThan(sourcePriority(existingEntry.source));
+		expect(resolveDuplicateAction(discovery, { existingEntry })).toBe("skip");
+	});
+});

--- a/src/process/duplicate-action.ts
+++ b/src/process/duplicate-action.ts
@@ -6,12 +6,14 @@ import { getPriority } from "../sources/index.ts";
 
 export type DuplicateAction = "replace" | "refresh" | "skip";
 
+const UNKNOWN_SOURCE_PRIORITY = 9;
+
 /** Source priority for dedup, delegated to source.priority. */
 export function sourcePriority(source: string): number {
 	try {
 		return getPriority(source as Entry["source"]);
 	} catch {
-		return 9;
+		return UNKNOWN_SOURCE_PRIORITY;
 	}
 }
 

--- a/src/process/duplicate-action.ts
+++ b/src/process/duplicate-action.ts
@@ -1,0 +1,31 @@
+import "../core/temporal.ts";
+
+import type { DuplicateCheck } from "../core/dedup.ts";
+import type { DiscoveryCandidate, Entry } from "../core/types.ts";
+import { getPriority } from "../sources/index.ts";
+
+export type DuplicateAction = "replace" | "refresh" | "skip";
+
+/** Source priority for dedup, delegated to source.priority. */
+export function sourcePriority(source: string): number {
+	try {
+		return getPriority(source as Entry["source"]);
+	} catch {
+		return 9;
+	}
+}
+
+/** Decide what to do with a duplicate candidate based on source priorities. */
+export function resolveDuplicateAction(
+	discovery: Pick<DiscoveryCandidate, "source">,
+	dup: Pick<DuplicateCheck, "existingEntry">,
+): DuplicateAction {
+	if (!dup.existingEntry) return "skip";
+
+	const candidatePriority = sourcePriority(discovery.source);
+	const existingPriority = sourcePriority(dup.existingEntry.source);
+
+	if (candidatePriority < existingPriority) return "replace";
+	if (candidatePriority === existingPriority) return "refresh";
+	return "skip";
+}

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -16,42 +16,18 @@ import { getEntryRepo, saveEntry } from "../core/store.ts";
 import type { CategorizedEntry, DiscoveryCandidate, Entry } from "../core/types.ts";
 import { loadDiscoveryLines } from "../discover/writer.ts";
 import { classifyEntry } from "../enrich/classify.ts";
-import { extractId, getPriority } from "../sources/index.ts";
+import { extractId } from "../sources/index.ts";
+import { resolveDuplicateAction, sourcePriority } from "./duplicate-action.ts";
 
 const ROOT_DIR = join(import.meta.dir, "..", "..");
 const DATA_DIR = join(ROOT_DIR, "data");
 const CACHE_DIR = join(ROOT_DIR, ".cache");
 const FILTERED_DIR = join(CACHE_DIR, "filtered");
 
-/** Source priority for dedup — delegated to source.priority. */
-function sourcePriority(source: string): number {
-	try {
-		return getPriority(source as Entry["source"]);
-	} catch {
-		return 9;
-	}
-}
-
 // biome-ignore lint/suspicious/noConsole: CLI output
 const log = console.log;
 
 // ─── Duplicate resolution ──────────────────────────────────────────────────────
-
-type DuplicateAction = "replace" | "refresh" | "skip";
-
-/** Decide what to do with a duplicate candidate based on source priorities. */
-function resolveDuplicateAction(
-	discovery: DiscoveryCandidate,
-	dup: { existingEntry?: CategorizedEntry },
-): DuplicateAction {
-	if (!dup.existingEntry) return "skip";
-
-	const candidatePriority = sourcePriority(discovery.source);
-	const existingPriority = sourcePriority(dup.existingEntry.source);
-
-	if (candidatePriority < existingPriority) return "replace";
-	return "refresh";
-}
 
 /** Merge fresh metadata from a same-source candidate into an existing entry. */
 function refreshExistingEntry(


### PR DESCRIPTION
## Summary

Thanks for maintaining this project and the daily discovery pipeline.

This PR prevents lower-priority duplicate candidates from refreshing entries created by higher-priority sources. It keeps the source-priority model intact by preserving source-specific metadata when the duplicate candidate comes from a lower-priority source.

## Problem Observed

After recent daily pipeline runs, some entries can keep their higher-priority identity, such as `source: "npm-search"` and an npm package URL, while their metadata has been refreshed into a lower-priority source shape such as GitHub metadata.

For npm entries, this can remove npm-specific fields like `npm_name`, `npm_downloads_monthly`, and `npm_downloads_weekly`. The README popularity column and sorting depend on those fields, so affected entries can lose their download count display and move much lower in the generated README.

## Root Cause

The duplicate handling currently refreshes any duplicate candidate that is not a higher-priority replacement. When a GitHub candidate matches an existing npm entry through `github_url`, the GitHub candidate can refresh the npm entry and replace its npm metadata with GitHub metadata.

That is not consistent with the source-priority model: a lower-priority source should not refresh and overwrite source-specific metadata already stored from a higher-priority source.

## Changes

- Move duplicate action resolution into a small side-effect-free helper.
- Keep replacement behavior when the candidate source has higher priority.
- Keep refresh behavior for same-priority duplicates.
- Skip lower-priority duplicates so existing source-specific metadata is preserved.
- Add regression tests for replace, refresh, and skip decisions.

## Why Generated Data Is Not Included

This PR intentionally does not commit generated README or data changes. The daily pipeline owns those generated artifacts, and after this processing logic is merged the next regeneration can update affected entries using the corrected duplicate handling.

Keeping the PR limited to code and tests should make the behavior change easier to review.

## Validation

- `bun run check`
- `bun test`
- Simulated the local pipeline path and confirmed lower-priority duplicates are skipped during processing.